### PR TITLE
feat: page wait until load

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -238,7 +238,7 @@ const crawl = async opt => {
         await page.setUserAgent(options.userAgent);
         const tracker = createTracker(page);
         try {
-          await page.goto(pageUrl, { waitUntil: "networkidle0" });
+          await page.goto(pageUrl, { waitUntil: "load" });
         } catch (e) {
           e.message = augmentTimeoutError(e.message, tracker);
           throw e;


### PR DESCRIPTION
Issue: React-snap was failing with `TimeoutError: Navigation Timeout Exceeded: 30000ms exceeded` due to a heavier UI process (ie. Hero Banner gradient flow animation).

Change: Page navigation waits until load (ie. navigation to be finished when the load event is fired) instead of networkidle0 (ie. consider navigation to be finished when there are no more than 0 network connections for at least 500 ms).