### PR TITLE
feat(sitemap): create tests and get routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const defaultOptions = {
     cache: true
   },
   puppeteerArgs: [],
+  generateSitemap: true,
   puppeteerExecutablePath: undefined,
   puppeteerIgnoreHTTPSErrors: false,
   publicPath: "/",
@@ -258,6 +259,26 @@ const removeBlobs = async opt => {
       }
     });
   });
+};
+
+/**
+ *
+ * @param {{page: Page}} opt
+ * @return Promise
+ */
+ const generateSitemap = async opt => {
+  const { page, pageUrl, indexRoutes } = opt;
+  try{
+    console.log('generate sitemap function')
+    console.log('-start-')
+    console.log(pageUrl)
+    console.log(indexRoutes)
+    indexRoutes.push(pageUrl)
+    console.log(indexRoutes)
+    console.log('-end-')
+  } catch (e) {
+    return Promise.reject(e.message);
+  }
 };
 
 /**
@@ -695,6 +716,7 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
   const ajaxCache = {};
   const { http2PushManifest } = options;
   const http2PushManifestItems = {};
+  const indexRoutes = [];
 
   await crawl({
     options,
@@ -730,9 +752,11 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
     },
     afterFetch: async ({ page, route, browser, addToQueue }) => {
       const pageUrl = `${basePath}${route}`;
+      await console.log('--AFTER FETCH--')
       if (options.removeStyleTags) await removeStyleTags({ page });
       if (options.removeScriptTags) await removeScriptTags({ page });
       if (options.removeBlobs) await removeBlobs({ page });
+      if (options.generateSitemap) await generateSitemap({ page, pageUrl, indexRoutes });
       if (options.inlineCss) {
         const { cssFiles } = await inlineCss({
           page,
@@ -875,6 +899,14 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
           `${destinationDir}/http2-push-manifest.json`,
           JSON.stringify(manifest)
         );
+      }
+      if (generateSitemap) {
+        console.log("@@--ON FILE END SITEMAP--@@")
+        console.log("---")
+        head = "<?xml version=\"1.0\" encoding=\"UTF-8\"?\>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+        tail = "</urlset>"
+        console.log(indexRoutes)
+        console.log("@@@@")
       }
     }
   });

--- a/tests/generateSitemap.test.js
+++ b/tests/generateSitemap.test.js
@@ -1,0 +1,46 @@
+// FIX: tests are slow - use unit tests instead of integration tests
+// TODO: capture console log from run function
+const fs = require("fs");
+const writeFileSpy = jest.spyOn(fs, "writeFile");
+writeFileSpy.mockImplementation((file, data, cb) => cb());
+
+const { mockFs } = require("./helper.js");
+const { run } = require("./../index.js");
+const snapRun = (fs, options) =>
+  run(
+    {
+      // for Travis CI
+      puppeteerArgs: ["--no-sandbox", "--disable-setuid-sandbox"],
+      // sometimes web server from previous test have not enough time to shut down
+      // as a result you get `Error: listen EADDRINUSE :::45678`
+      // to prevent this we use random port
+      port: Math.floor(Math.random() * 1000 + 45000),
+      ...options
+    },
+    {
+      fs
+    }
+  );
+
+describe("generateSitemap", () => {
+    console.log('\n--describing generate sitemap test--\n')
+    const source = "tests/examples/many-pages";
+    const include = ["/index.html"];
+    const { fs, filesCreated, content } = mockFs();
+    beforeAll(() => snapRun(fs, { source, include }));
+    test("removes blob resources from final html but sitemap", () => {
+      console.log('--fs')
+      console.log(fs)
+      console.log('--content(0)')
+      console.log(content(0))
+      expect(content(0)).not.toMatch('<link rel="stylesheet" href="blob:');
+    });
+});
+
+describe.skip("publicPath", () => {});
+
+describe.skip("skipThirdPartyRequests", () => {});
+
+describe.skip("waitFor", () => {});
+
+describe.skip("externalServer", () => {});


### PR DESCRIPTION
- Create jest test to run the generateSitemap function. Run `yarn run test generateSitemap.test.js`
- Append all of the routes crawled during react-snap pre-render to an array