### PR TITLE
 fix(sitemap): static production baseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -904,35 +904,34 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
         console.log(destinationDir)
         console.log("@--Done--@")
         
+        /*let sitemapPageData = head + indexRoutes + tail**/
+        let sitemapPageDate = "2021-04-02T06:51:09+00:00"
+        let sitemapBlogDate = "2021-04-16T22:37:16+00:00"
+
+        let sitemapData =
+        "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\>"
+        + "\n\t<sitemap\>"
+        +   "\n\t\t<loc>https://cctech.io/post-sitemap.xml</loc\>"
+        +   `\n\t\t<lastmod>${sitemapBlogDate}</lastmod\>`
+        + "\n\t</sitemap\>"
+        + "\n\t<sitemap\>"
+        +     "\n\t\t<loc>https://old.cctech.io/page-sitemap.xml</loc\>"
+        +     `\n\t\t<lastmod>${sitemapPageDate}</lastmod\>`
+        +   "\n\t</sitemap\>"
+        + "\n</sitemapindex\>"
+
+        let sitemapPageData = (routes) => {
+          head = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "\n<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">"
+          body = ""
+          routes.forEach(
+            route => body += `\n\t<url><loc>${route}</loc></url>`
+          )
+          tail = "\n</urlset>"
+          return head + body + tail
+        }
+
         try {
-          /*let sitemapPageData = head + indexRoutes + tail**/
-          let sitemapPageDate = "2021-04-02T06:51:09+00:00"
-          let sitemapBlogDate = "2021-04-16T22:37:16+00:00"
-
-          let sitemapData =
-          "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\>"
-          + "\n\t<sitemap\>"
-          +   "\n\t\t<loc>https://cctech.io/post-sitemap.xml</loc\>"
-          +   `\n\t\t<lastmod>${sitemapBlogDate}</lastmod\>`
-          + "\n\t</sitemap\>"
-          + "\n\t<sitemap\>"
-          +     "\n\t\t<loc>https://old.cctech.io/page-sitemap.xml</loc\>"
-          +     `\n\t\t<lastmod>${sitemapPageDate}</lastmod\>`
-          +   "\n\t</sitemap\>"
-          + "\n</sitemapindex\>"
-
-          let sitemapPageData = (routes) => {
-            head = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                  + "\n<urlset xmlns=\"https://www.sitemaps.org/schemas/sitemap/0.9\">"
-            body = ""
-            routes.forEach(
-              route => body += `\n\t<url><loc>${route}</loc></url>`
-            )
-            tail = "\n</urlset>"
-
-            return head + body + tail
-          }
-        
           nativeFs.writeFileSync(
             `${destinationDir}/page-sitemap.xml`,
             sitemapPageData(indexRoutes)
@@ -942,7 +941,6 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
             `${destinationDir}/sitemap.xml`,
             sitemapData
           );
-
         } catch (err) {
           console.log('Error writing sitemap data:' + err.message)
         }

--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ const removeBlobs = async opt => {
  * @return Promise
  */
  const generateSitemap = async opt => {
-  const { page, pageUrl, indexRoutes } = opt;
+  const { pageUrl, indexRoutes } = opt;
   try{
     indexRoutes.push(pageUrl)
   } catch (e) {

--- a/index.js
+++ b/index.js
@@ -746,10 +746,11 @@ const run = async (userOptions, { fs } = { fs: nativeFs }) => {
     },
     afterFetch: async ({ page, route, browser, addToQueue }) => {
       const pageUrl = `${basePath}${route}`;
+      const prodPageUrl = `https://cctech.io${route}`;
       if (options.removeStyleTags) await removeStyleTags({ page });
       if (options.removeScriptTags) await removeScriptTags({ page });
       if (options.removeBlobs) await removeBlobs({ page });
-      if (options.generateSitemap) await generateSitemap({ page, pageUrl, indexRoutes });
+      if (options.generateSitemap) await generateSitemap({ prodPageUrl, indexRoutes });
       if (options.inlineCss) {
         const { cssFiles } = await inlineCss({
           page,


### PR DESCRIPTION
- use the static `https://cctech.io` as the baseUrl for the sitemap routes
- move sitemap string creation outside of the try block
- remove the unused `page` parameter in the generateSitemap function